### PR TITLE
Fix broken werkzeug import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         "gunicorn==19.7.1",
         "requests>=2.20.0,<3.0",
         "Flask==1.0.2",
-        "Flask-Admin==1.5.3",
+        "Flask-Admin==1.5.5",
         "Flask-SQLAlchemy==2.3.2",
         "Flask-Login==0.4.1",
         "Flask-WTF>=0.14,<0.15",


### PR DESCRIPTION
Update version of Flask-admin to include this fix https://github.com/flask-admin/flask-admin/commit/09639f71bd3f58896fc48bcc5fa324de0920a069#diff-401640c72e6a6b2a48e711090af0534c

TL;DR - in werkzeug==1.0.0 top level imports has been refactored, and since this version is installed we also require the version of Flask admin with corresponding fixes.

W/o the fix:
```
% docker run -it -p 3000:3000 -p 3001:3001 -p 8080:8080 --rm --name python_demo -v $(pwd):/opt/app/src python_demo
Traceback (most recent call last):
  File "demo/app.py", line 8, in <module>
    import processor
  File "/opt/app/src/demo/processor.py", line 5, in <module>
    from flask_admin.contrib.sqla import ModelView
  File "/usr/local/lib/python3.7/site-packages/flask_admin/contrib/sqla/__init__.py", line 2, in <module>
    from .view import ModelView
  File "/usr/local/lib/python3.7/site-packages/flask_admin/contrib/sqla/view.py", line 18, in <module>
    from flask_admin.model import BaseModelView
  File "/usr/local/lib/python3.7/site-packages/flask_admin/model/__init__.py", line 2, in <module>
    from .base import BaseModelView
  File "/usr/local/lib/python3.7/site-packages/flask_admin/model/base.py", line 8, in <module>
    from werkzeug import secure_filename
ImportError: cannot import name 'secure_filename' from 'werkzeug' (/usr/local/lib/python3.7/site-packages/werkzeug/__init__.py)
```